### PR TITLE
feat(bridge): support primitive `adbPath` expansion

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -83,20 +83,19 @@ function resolvePath(from: string): string {
 function getAdbExecutable(): string {
     const adbPath = vscode.workspace
         .getConfiguration("android-webview-debug")
-        .get("adbPath");
+        .get<string>("adbPath");
     if (adbPath) return resolvePath(adbPath);
 
     return "adb";
 }
-
 
 export async function test(): Promise<void> {
     try {
         await adb.version({
             executable: getAdbExecutable()
         });
-    } catch (err) {
-        if (err.code === "ENOENT") {
+    } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
             throw new Error("Failed to locate ADB executable.");
         }
 
@@ -140,12 +139,12 @@ async function getSockets(serial: string): Promise<string[]> {
             continue;
         }
 
-        const path = columns[7];
-        if (!path.startsWith("@") || !path.includes("_devtools_remote")) {
+        const colPath = columns[7];
+        if (!colPath.startsWith("@") || !colPath.includes("_devtools_remote")) {
             continue;
         }
 
-        result.push(path.substr(1));
+        result.push(colPath.substr(1));
     }
 
     return result;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -57,24 +57,25 @@ function resolvePath(from: string): string {
     const substituted = from.replace(
         /(?:^(~|\.{1,2}))(?=\/)|\$(\w+)/g,
         (_, tilde, env) => {
+            // $HOME/adb -> /Users/<user>/adb
+            if (env) return process.env[env] ?? "";
+
             // ~/adb -> /Users/<user>/adb
             if (tilde === "~") return os.homedir();
 
-            // ./adb -> <workspace>/adb
-            if (tilde === ".")
-                return vscode.workspace.workspaceFolders[0]?.uri.fsPath;
-         
-            // ../adb -> <workspace>/../adb
-            if (tilde === "..")
-                return vscode.workspace.workspaceFolders[0]?.uri.fsPath + "/..";
+            const fsPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+            if (!fsPath) return "";
 
-            // $HOME/adb -> /Users/<user>/adb
-            if (env) return process.env[env] ?? "";
+            // ./adb -> <workspace>/adb
+            if (tilde === ".") return fsPath;
+
+            // ../adb -> <workspace>/../adb
+            if (tilde === "..") return fsPath + "/..";
 
             return "";
         }
     );
-    
+
     const resolved = path.resolve(substituted);
     return resolved;
 }


### PR DESCRIPTION
In some setups, the `adb` may not be in the `$PATH`, but be located relative to the workspace directory or accessible via some other environment `$VAR`. This is currently not supported via the `adbPath` configuration.

This PR adds support for primitive Bash-like path / variable expansion for `adbPath`.

- `~/adb` → `/Users/<user>/adb`
  Replace leading `~/` with user home directory. Does _not_ support other Bash-isms, like `~name` or `~1`.
- `./adb` → `<workspace>/adb`
  Replace leading `./` with primary workspace directory.
- `$HOME/adb` → `/Users/<user>/adb`
  Substitute `$VAR` with environment variables.
- `../tools/adb` → `<workspace>/../adb`
  Resolve `..` directory traversal.

Thanks your your great extension!